### PR TITLE
Added a sign out popup/modal to every ejs page

### DIFF
--- a/server.js
+++ b/server.js
@@ -44,8 +44,8 @@ app.post("/login", controller.postLogin);
 
 app.post("/register", controller.postRegister);
 
-app.post("/reminders", (req, res) => {
-  console.log(req.body);
+app.post("/logout", (req, res) => {
+  //logout logic from the backend
 });
 
 app.listen(port, () => {

--- a/views/contacts.ejs
+++ b/views/contacts.ejs
@@ -43,7 +43,7 @@
         <li><a class="dropdown-item" href="#">Settings</a></li>
         <li><a class="dropdown-item" href="#">Profile</a></li>
         <li><hr class="dropdown-divider"></li>
-        <li><a class="dropdown-item" href="#">Sign out</a></li>
+        <li><a class="dropdown-item" href="#" data-bs-toggle="modal" data-bs-target="#signOutModal">Sign out</a></li>
       </ul>
     </div>
   </div>
@@ -134,5 +134,28 @@
   });
 </script>
 <!-- TEMPORARY PLACEHOLDER DATA -->
+ 
+<!-- Sign Out Modal -->
+  <div class="modal fade" id="signOutModal" tabindex="-1" aria-labelledby="signOutModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="signOutModalLabel">Confirm Sign Out</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          Are you sure you want to sign out?
+        </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+            
+            <!-- <form action="/logout" method="POST" style="display: inline;">
+              <button type="submit" class="btn btn-danger">Sign Out</button>
+            </form> (Can be added when backend logic for logout is ready.)-->
 
+            <a href="/login" class="btn btn-danger">Sign Out</a> <!-- Temporary redirect to /login -->
+          </div>
+      </div>
+    </div>
+  </div>
 <%- include("partials/footer.ejs") %>

--- a/views/documents.ejs
+++ b/views/documents.ejs
@@ -43,11 +43,33 @@
         <li><a class="dropdown-item" href="#">Settings</a></li>
         <li><a class="dropdown-item" href="#">Profile</a></li>
         <li><hr class="dropdown-divider"></li>
-        <li><a class="dropdown-item" href="#">Sign out</a></li>
+        <li><a class="dropdown-item" href="#" data-bs-toggle="modal" data-bs-target="#signOutModal">Sign out</a></li>
       </ul>
     </div>
   </div>
 <!--START CODING HERE-->
+<!-- Sign Out Modal -->
+  <div class="modal fade" id="signOutModal" tabindex="-1" aria-labelledby="signOutModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="signOutModalLabel">Confirm Sign Out</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          Are you sure you want to sign out?
+        </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+            
+            <!-- <form action="/logout" method="POST" style="display: inline;">
+              <button type="submit" class="btn btn-danger">Sign Out</button>
+            </form> (Can be added when backend logic for logout is ready.)-->
 
+            <a href="/login" class="btn btn-danger">Sign Out</a> <!-- Temporary redirect to /login -->
+          </div>
+      </div>
+    </div>
+  </div>
 <!--FINISH CODING HERE-->
 <%- include("partials/footer.ejs") %>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -43,7 +43,7 @@
         <li><a class="dropdown-item" href="#">Settings</a></li>
         <li><a class="dropdown-item" href="#">Profile</a></li>
         <li><hr class="dropdown-divider"></li>
-        <li><a class="dropdown-item" href="#">Sign out</a></li>
+        <li><a class="dropdown-item" href="#" data-bs-toggle="modal" data-bs-target="#signOutModal">Sign out</a></li>
       </ul>
     </div>
   </div>
@@ -53,7 +53,30 @@
       <h2 class="text-white">Job Applications</h2>
       <a href="/open-job-form" class="btn btn-primary">Add Application</a>
     </div>
-    
+    <!-- Sign Out Modal -->
+  <div class="modal fade" id="signOutModal" tabindex="-1" aria-labelledby="signOutModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="signOutModalLabel">Confirm Sign Out</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          Are you sure you want to sign out?
+        </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+            
+            <!-- <form action="/logout" method="POST" style="display: inline;">
+              <button type="submit" class="btn btn-danger">Sign Out</button>
+            </form> (Can be added when backend logic for logout is ready.)-->
+
+            <a href="/login" class="btn btn-danger">Sign Out</a> <!-- Temporary redirect to /login -->
+          </div>
+      </div>
+    </div>
+  </div>
+
     <!-- Search Bar -->
     <div class="mb-4">
       <div class="input-group">

--- a/views/job-detail.ejs
+++ b/views/job-detail.ejs
@@ -45,7 +45,7 @@
         <li><a class="dropdown-item" href="#">Settings</a></li>
         <li><a class="dropdown-item" href="#">Profile</a></li>
         <li><hr class="dropdown-divider"></li>
-        <li><a class="dropdown-item" href="#">Sign out</a></li>
+        <li><a class="dropdown-item" href="#" data-bs-toggle="modal" data-bs-target="#signOutModal">Sign out</a></li>
       </ul>
     </div>
   </div>
@@ -144,6 +144,29 @@
           renderContacts(filteredContacts);
       });
   });
-</script>
+</script> 
+<!-- Sign Out Modal -->
+  <div class="modal fade" id="signOutModal" tabindex="-1" aria-labelledby="signOutModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="signOutModalLabel">Confirm Sign Out</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          Are you sure you want to sign out?
+        </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+            
+            <!-- <form action="/logout" method="POST" style="display: inline;">
+              <button type="submit" class="btn btn-danger">Sign Out</button>
+            </form> (Can be added when backend logic for logout is ready.)-->
+
+            <a href="/login" class="btn btn-danger">Sign Out</a> <!-- Temporary redirect to /login -->
+          </div>
+      </div>
+    </div>
+  </div>
 <!--FINISH CODING HERE-->
 <%- include("partials/footer.ejs") %>

--- a/views/reminders.ejs
+++ b/views/reminders.ejs
@@ -44,7 +44,7 @@
       <li><a class="dropdown-item" href="#">Settings</a></li>
       <li><a class="dropdown-item" href="#">Profile</a></li>
       <li><hr class="dropdown-divider"></li>
-      <li><a class="dropdown-item" href="#">Sign out</a></li>
+      <li><a class="dropdown-item" href="#" data-bs-toggle="modal" data-bs-target="#signOutModal">Sign out</a></li>
     </ul>
   </div>
 </div>
@@ -68,6 +68,30 @@
     </div>
   </div>
 </div>
+
+    <!-- Sign Out Modal -->
+  <div class="modal fade" id="signOutModal" tabindex="-1" aria-labelledby="signOutModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="signOutModalLabel">Confirm Sign Out</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          Are you sure you want to sign out?
+        </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+            
+            <!-- <form action="/logout" method="POST" style="display: inline;">
+              <button type="submit" class="btn btn-danger">Sign Out</button>
+            </form> (Can be added when backend logic for logout is ready.)-->
+
+            <a href="/login" class="btn btn-danger">Sign Out</a> <!-- Temporary redirect to /login -->
+          </div>
+      </div>
+    </div>
+  </div>
      
 
 


### PR DESCRIPTION
Notes:
- Added a logout modal/popup for every pages (index.ejs, ... , documents.ejs)
- Logout logic doesn't exist yet, so a temporary href to /login is placed for now.
- An post endpoint for "/logout" is already set up in server.js, backend logic for the actual logout can be added. 